### PR TITLE
Add get_idea tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aha-mcp
 
-Model Context Protocol (MCP) server for accessing Aha! records through the MCP. This integration enables seamless interaction with Aha! features, requirements, and pages directly through the Model Context Protocol.
+Model Context Protocol (MCP) server for accessing Aha! records through the MCP. This integration enables seamless interaction with Aha! features, requirements, ideas, and pages directly through the Model Context Protocol.
 
 ## Prerequisites
 
@@ -240,6 +240,29 @@ Searches for Aha! documents.
   "total_results": 1
 }
 ```
+### 4. get_idea
+
+Retrieves an Aha! idea by reference number.
+
+**Parameters:**
+
+- `reference` (required): Reference number of the idea (e.g., "RAS-I-50")
+
+**Example:**
+```json
+{
+  "reference": "RAS-I-50"
+}
+```
+
+**Response:**
+```json
+{
+  "reference_num": "RAS-I-50",
+  "name": "Idea title"
+}
+```
+
 
 ## Example Queries
 
@@ -247,6 +270,7 @@ Searches for Aha! documents.
 - "Fetch the product roadmap page ABC-N-213"
 - "Search for pages about launch planning"
 - "Get requirement ADT-123-1"
+- "Get idea RAS-I-50"
 - "Find all pages mentioning Q2 goals"
 
 ## Configuration Options

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -4,10 +4,12 @@ import {
   FEATURE_REF_REGEX,
   REQUIREMENT_REF_REGEX,
   NOTE_REF_REGEX,
+  IDEA_REF_REGEX,
   Record,
   FeatureResponse,
   RequirementResponse,
   PageResponse,
+  IdeaResponse,
   SearchResponse,
 } from "./types.js";
 import {
@@ -18,7 +20,11 @@ import {
 } from "./queries.js";
 
 export class Handlers {
-  constructor(private client: GraphQLClient) {}
+  constructor(
+    private client: GraphQLClient,
+    private domain: string,
+    private token: string,
+  ) {}
 
   async handleGetRecord(request: any) {
     const { reference } = request.params.arguments as { reference: string };
@@ -84,6 +90,75 @@ export class Handlers {
       throw new McpError(
         ErrorCode.InternalError,
         `Failed to fetch record: ${errorMessage}`
+      );
+    }
+  }
+
+  async handleGetIdea(request: any) {
+    const { reference } = request.params.arguments as { reference: string };
+
+    if (!reference) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Reference number is required",
+      );
+    }
+
+    if (!IDEA_REF_REGEX.test(reference)) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        "Invalid reference number format. Expected ABC-I-213",
+      );
+    }
+
+    try {
+      const response = await fetch(
+        `https://${this.domain}.aha.io/api/v1/ideas/${reference}`,
+        {
+          headers: {
+            Authorization: `Bearer ${this.token}`,
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          },
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error(`API responded with status ${response.status}`);
+      }
+
+      const data = (await response.json()) as IdeaResponse;
+
+      if (!data.idea) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `No idea found for reference ${reference}`,
+            },
+          ],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(data.idea, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      if (error instanceof McpError) {
+        throw error;
+      }
+
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      console.error("API Error:", errorMessage);
+      throw new McpError(
+        ErrorCode.InternalError,
+        `Failed to fetch idea: ${errorMessage}`,
       );
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ class AhaMcp {
       }
     );
 
-    this.handlers = new Handlers(client);
+    this.handlers = new Handlers(client, AHA_DOMAIN!, AHA_API_TOKEN!);
     this.setupToolHandlers();
 
     this.server.onerror = (error) => console.error("[MCP Error]", error);
@@ -96,6 +96,20 @@ class AhaMcp {
           },
         },
         {
+          name: "get_idea",
+          description: "Get an Aha! idea by reference number",
+          inputSchema: {
+            type: "object",
+            properties: {
+              reference: {
+                type: "string",
+                description: "Reference number (e.g., ABC-I-213)",
+              },
+            },
+            required: ["reference"],
+          },
+        },
+        {
           name: "search_documents",
           description: "Search for Aha! documents",
           inputSchema: {
@@ -122,6 +136,8 @@ class AhaMcp {
         return this.handlers.handleGetRecord(request);
       } else if (request.params.name === "get_page") {
         return this.handlers.handleGetPage(request);
+      } else if (request.params.name === "get_idea") {
+        return this.handlers.handleGetIdea(request);
       } else if (request.params.name === "search_documents") {
         return this.handlers.handleSearchDocuments(request);
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,10 +30,15 @@ export interface PageResponse {
   };
 }
 
+export interface IdeaResponse {
+  idea: unknown;
+}
+
 // Regular expressions for validating reference numbers
 export const FEATURE_REF_REGEX = /^([A-Z][A-Z0-9]*)-(\d+)$/;
 export const REQUIREMENT_REF_REGEX = /^([A-Z][A-Z0-9]*)-(\d+)-(\d+)$/;
 export const NOTE_REF_REGEX = /^([A-Z][A-Z0-9]*)-N-(\d+)$/;
+export const IDEA_REF_REGEX = /^([A-Z][A-Z0-9]*)-I-(\d+)$/;
 
 export interface SearchNode {
   name: string | null;


### PR DESCRIPTION
## Summary
- fetch Aha! ideas via REST
- expose new `get_idea` tool in the MCP server
- validate idea reference numbers
- document idea tool and example usage
- ignore node_modules

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68506c91149c832aa9b5939485febb2c