### PR TITLE
Add pagination support to search_documents tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,13 +215,17 @@ Searches for Aha! documents.
 
 - `query` (required): Search query string
 - `searchableType` (optional): Type of document to search for (e.g., "Page"). Defaults to "Page"
+- `page` (optional): Page number for pagination. Defaults to `1`
+- `perPage` (optional): Number of results per page. Defaults to `20`
 
 **Example:**
 
 ```json
 {
   "query": "product roadmap",
-  "searchableType": "Page"
+  "searchableType": "Page",
+  "page": 2,
+  "perPage": 10
 }
 ```
 
@@ -229,15 +233,18 @@ Searches for Aha! documents.
 
 ```json
 {
-  "results": [
+  "nodes": [
     {
       "reference_num": "ABC-N-123",
       "name": "Product Roadmap 2025",
-      "type": "Page",
+      "searchableType": "Page",
       "url": "https://company.aha.io/pages/ABC-N-123"
     }
   ],
-  "total_results": 1
+  "currentPage": 2,
+  "totalCount": 50,
+  "totalPages": 5,
+  "isLastPage": false
 }
 ```
 ### 4. get_idea

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -224,9 +224,16 @@ export class Handlers {
   }
 
   async handleSearchDocuments(request: any) {
-    const { query, searchableType = "Page" } = request.params.arguments as {
+    const {
+      query,
+      searchableType = "Page",
+      page,
+      perPage,
+    } = request.params.arguments as {
       query: string;
       searchableType?: string;
+      page?: number;
+      perPage?: number;
     };
 
     if (!query) {
@@ -239,6 +246,8 @@ export class Handlers {
         {
           query,
           searchableType: [searchableType],
+          page,
+          perPage,
         }
       );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,16 @@ class AhaMcp {
                 description: "Type of document to search for (e.g., Page)",
                 default: "Page",
               },
+              page: {
+                type: "integer",
+                description: "Page number for pagination",
+                default: 1,
+              },
+              perPage: {
+                type: "integer",
+                description: "Number of results per page",
+                default: 20,
+              },
             },
             required: ["query"],
           },

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -40,8 +40,17 @@ export const getRequirementQuery = `
 `;
 
 export const searchDocumentsQuery = `
-  query SearchDocuments($query: String!, $searchableType: [String!]!) {
-    searchDocuments(filters: {query: $query, searchableType: $searchableType}) {
+  query SearchDocuments(
+    $query: String!
+    $searchableType: [String!]!
+    $page: Int
+    $perPage: Int
+  ) {
+    searchDocuments(
+      filters: { query: $query, searchableType: $searchableType }
+      page: $page
+      perPage: $perPage
+    ) {
       nodes {
         name
         url


### PR DESCRIPTION
## Summary
- support optional page and perPage vars in searchDocuments query
- forward new pagination params from handler
- extend search_documents tool schema
- document pagination usage

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68516a2c8cf0832abc9f634dacf43776