### PR TITLE
Fix searchDocuments pagination argument

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -49,7 +49,7 @@ export const searchDocumentsQuery = `
     searchDocuments(
       filters: { query: $query, searchableType: $searchableType }
       page: $page
-      per_page: $perPage
+      perPage: $perPage
     ) {
       nodes {
         name


### PR DESCRIPTION
## Summary
- use correct `perPage` argument in searchDocuments query

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851765e311c832aa39034e73180d664