### PR TITLE
Remove per_page support

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,6 @@ Searches for Aha! documents.
 - `query` (required): Search query string
 - `searchableType` (optional): Type of document to search for (e.g., "Page"). Defaults to "Page"
 - `page` (optional): Page number for pagination. Defaults to `1`
-- `per_page` (optional): Number of results per page. Defaults to `20`
 
 **Example:**
 
@@ -224,8 +223,7 @@ Searches for Aha! documents.
 {
   "query": "product roadmap",
   "searchableType": "Page",
-  "page": 2,
-  "per_page": 10
+  "page": 2
 }
 ```
 

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -228,12 +228,10 @@ export class Handlers {
       query,
       searchableType = "Page",
       page,
-      per_page,
     } = request.params.arguments as {
       query: string;
       searchableType?: string;
       page?: number;
-      per_page?: number;
     };
 
     if (!query) {
@@ -247,7 +245,6 @@ export class Handlers {
           query,
           searchableType: [searchableType],
           page,
-          per_page,
         }
       );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,11 +129,6 @@ class AhaMcp {
                 description: "Page number for pagination",
                 default: 1,
               },
-              per_page: {
-                type: "integer",
-                description: "Number of results per page",
-                default: 20,
-              },
             },
             required: ["query"],
           },

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -44,12 +44,10 @@ export const searchDocumentsQuery = `
     $query: String!
     $searchableType: [String!]!
     $page: Int
-    $per_page: Int
   ) {
     searchDocuments(
       filters: { query: $query, searchableType: $searchableType }
       page: $page
-      per_page: $per_page
     ) {
       nodes {
         name


### PR DESCRIPTION
## Summary
- remove `per_page` option from query schema and handlers
- strip `per_page` from GraphQL query
- update README instructions for searching documents

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68518114c9a4832a88f4b5dd357a8e5c